### PR TITLE
impl_indexmap and impl_all are defined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 derive-new = "0.6"
-indexmap = "2.1"
 orx-closure = "0.1"
+indexmap = { version = "2.1", optional = true }
 ndarray = { version = "0.15", optional = true }
 
 [dev-dependencies]
@@ -19,4 +19,6 @@ harness = false
 
 [features]
 default = []
+impl_all = ["ndarray", "indexmap"]
 impl_ndarray = ["ndarray"]
+impl_indexmap = ["indexmap"]

--- a/src/impl_dim1/iterators/mapref_iter.rs
+++ b/src/impl_dim1/iterators/mapref_iter.rs
@@ -1,5 +1,4 @@
 use crate::scalar_asvec::Scalar;
-use indexmap::IndexMap;
 use orx_closure::{ClosureOptRef, ClosureOptRefOneOf2, ClosureOptRefOneOf3, ClosureOptRefOneOf4};
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
@@ -89,7 +88,8 @@ impl<T> MapRef<T> for BTreeMap<usize, T> {
         self.get(&key)
     }
 }
-impl<T> MapRef<T> for IndexMap<usize, T> {
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T> MapRef<T> for indexmap::IndexMap<usize, T> {
     #[inline(always)]
     fn get_ref_by_key(&self, key: usize) -> Option<&T> {
         self.get(&key)
@@ -97,7 +97,7 @@ impl<T> MapRef<T> for IndexMap<usize, T> {
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T> MapRef<T> for ndarray::Array1<T> {
     #[inline(always)]
     fn get_ref_by_key(&self, key: usize) -> Option<&T> {

--- a/src/impl_dim1/iterators/mapval_iter.rs
+++ b/src/impl_dim1/iterators/mapval_iter.rs
@@ -1,5 +1,4 @@
 use crate::scalar_asvec::Scalar;
-use indexmap::IndexMap;
 use orx_closure::{Closure, ClosureOneOf2, ClosureOneOf3, ClosureOneOf4};
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
@@ -91,7 +90,8 @@ impl<T: Clone + Copy> MapVal<T> for BTreeMap<usize, T> {
         self.get(&key).copied()
     }
 }
-impl<T: Clone + Copy> MapVal<T> for IndexMap<usize, T> {
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T: Clone + Copy> MapVal<T> for indexmap::IndexMap<usize, T> {
     #[inline(always)]
     fn get_val_by_key(&self, key: usize) -> Option<T> {
         self.get(&key).copied()
@@ -107,7 +107,7 @@ impl<T: Clone + Copy> MapVal<T> for Box<dyn Fn(usize) -> Option<T>> {
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T: Clone + Copy> MapVal<T> for ndarray::Array1<T> {
     #[inline(always)]
     fn get_val_by_key(&self, key: usize) -> Option<T> {

--- a/src/impl_dim2/iterators/mapref_iter.rs
+++ b/src/impl_dim2/iterators/mapref_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d2::Ind, scalar_asvec::Scalar, FunVecD1Ref};
-use indexmap::IndexMap;
 use orx_closure::{ClosureOptRef, ClosureOptRefOneOf2, ClosureOptRefOneOf3, ClosureOptRefOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -66,7 +65,8 @@ impl<T, V1: FunVecD1Ref<T>> MapRefD2<T> for BTreeMap<usize, V1> {
         self.get(&indices.0).and_then(|x| x.ref_at(indices.1))
     }
 }
-impl<T, V1: FunVecD1Ref<T>> MapRefD2<T> for IndexMap<usize, V1> {
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T, V1: FunVecD1Ref<T>> MapRefD2<T> for indexmap::IndexMap<usize, V1> {
     #[inline(always)]
     fn get_ref_by_key(&self, indices: Ind) -> Option<&T> {
         self.get(&indices.0).and_then(|x| x.ref_at(indices.1))
@@ -100,7 +100,7 @@ impl<C1, C2, C3, C4, T: ?Sized> MapRefD2<T> for ClosureOptRefOneOf4<C1, C2, C3, 
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T> MapRefD2<T> for ndarray::Array2<T> {
     #[inline(always)]
     fn get_ref_by_key(&self, key: Ind) -> Option<&T> {

--- a/src/impl_dim2/iterators/mapval_iter.rs
+++ b/src/impl_dim2/iterators/mapval_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d2::Ind, scalar_asvec::Scalar, FunVecD1};
-use indexmap::IndexMap;
 use orx_closure::{Closure, ClosureOneOf2, ClosureOneOf3, ClosureOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -67,7 +66,8 @@ impl<T: Clone + Copy, V1: FunVecD1<T>> MapValD2<T> for BTreeMap<usize, V1> {
         self.get(&indices.0).and_then(|x| x.val_at(indices.1))
     }
 }
-impl<T: Clone + Copy, V1: FunVecD1<T>> MapValD2<T> for IndexMap<usize, V1> {
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T: Clone + Copy, V1: FunVecD1<T>> MapValD2<T> for indexmap::IndexMap<usize, V1> {
     #[inline(always)]
     fn get_val_by_key(&self, indices: Ind) -> Option<T> {
         self.get(&indices.0).and_then(|x| x.val_at(indices.1))
@@ -111,7 +111,7 @@ impl<T: Clone + Copy> MapValD2<T> for Box<dyn Fn(Ind) -> Option<T>> {
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T: Clone + Copy> MapValD2<T> for ndarray::Array2<T> {
     #[inline(always)]
     fn get_val_by_key(&self, key: Ind) -> Option<T> {

--- a/src/impl_dim3/iterators/mapref_iter.rs
+++ b/src/impl_dim3/iterators/mapref_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d2::FunVecRefD2, funvec_d3::Ind, scalar_asvec::Scalar};
-use indexmap::IndexMap;
 use orx_closure::{ClosureOptRef, ClosureOptRefOneOf2, ClosureOptRefOneOf3, ClosureOptRefOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -70,7 +69,9 @@ impl<T, V2: FunVecRefD2<T>> MapRefD3<T> for BTreeMap<usize, V2> {
             .and_then(|x| x.ref_at(indices.1, indices.2))
     }
 }
-impl<T, V2: FunVecRefD2<T>> MapRefD3<T> for IndexMap<usize, V2> {
+
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T, V2: FunVecRefD2<T>> MapRefD3<T> for indexmap::IndexMap<usize, V2> {
     #[inline(always)]
     fn get_ref_by_key(&self, indices: Ind) -> Option<&T> {
         self.get(&indices.0)
@@ -105,7 +106,7 @@ impl<C1, C2, C3, C4, T: ?Sized> MapRefD3<T> for ClosureOptRefOneOf4<C1, C2, C3, 
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T> MapRefD3<T> for ndarray::Array3<T> {
     #[inline(always)]
     fn get_ref_by_key(&self, key: Ind) -> Option<&T> {

--- a/src/impl_dim3/iterators/mapval_iter.rs
+++ b/src/impl_dim3/iterators/mapval_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d2::FunVecD2, funvec_d3::Ind, scalar_asvec::Scalar};
-use indexmap::IndexMap;
 use orx_closure::{Closure, ClosureOneOf2, ClosureOneOf3, ClosureOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -71,7 +70,9 @@ impl<T: Clone + Copy, V2: FunVecD2<T>> MapValD3<T> for BTreeMap<usize, V2> {
             .and_then(|x| x.val_at(indices.1, indices.2))
     }
 }
-impl<T: Clone + Copy, V2: FunVecD2<T>> MapValD3<T> for IndexMap<usize, V2> {
+
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T: Clone + Copy, V2: FunVecD2<T>> MapValD3<T> for indexmap::IndexMap<usize, V2> {
     #[inline(always)]
     fn get_val_by_key(&self, indices: Ind) -> Option<T> {
         self.get(&indices.0)
@@ -116,7 +117,7 @@ impl<T: Clone + Copy> MapValD3<T> for Box<dyn Fn(Ind) -> Option<T>> {
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T: Clone + Copy> MapValD3<T> for ndarray::Array3<T> {
     #[inline(always)]
     fn get_val_by_key(&self, key: Ind) -> Option<T> {

--- a/src/impl_dim4/iterators/mapref_iter.rs
+++ b/src/impl_dim4/iterators/mapref_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d3::FunVecRefD3, funvec_d4::Ind, scalar_asvec::Scalar};
-use indexmap::IndexMap;
 use orx_closure::{ClosureOptRef, ClosureOptRefOneOf2, ClosureOptRefOneOf3, ClosureOptRefOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -70,7 +69,9 @@ impl<T, V3: FunVecRefD3<T>> MapRefD4<T> for BTreeMap<usize, V3> {
             .and_then(|x| x.ref_at(indices.1, indices.2, indices.3))
     }
 }
-impl<T, V3: FunVecRefD3<T>> MapRefD4<T> for IndexMap<usize, V3> {
+
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T, V3: FunVecRefD3<T>> MapRefD4<T> for indexmap::IndexMap<usize, V3> {
     #[inline(always)]
     fn get_ref_by_key(&self, indices: Ind) -> Option<&T> {
         self.get(&indices.0)
@@ -105,7 +106,7 @@ impl<C1, C2, C3, C4, T: ?Sized> MapRefD4<T> for ClosureOptRefOneOf4<C1, C2, C3, 
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T> MapRefD4<T> for ndarray::Array4<T> {
     #[inline(always)]
     fn get_ref_by_key(&self, key: Ind) -> Option<&T> {

--- a/src/impl_dim4/iterators/mapval_iter.rs
+++ b/src/impl_dim4/iterators/mapval_iter.rs
@@ -1,5 +1,4 @@
 use crate::{funvec_d3::FunVecD3, funvec_d4::Ind, scalar_asvec::Scalar};
-use indexmap::IndexMap;
 use orx_closure::{Closure, ClosureOneOf2, ClosureOneOf3, ClosureOneOf4};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -71,7 +70,9 @@ impl<T: Clone + Copy, V3: FunVecD3<T>> MapValD4<T> for BTreeMap<usize, V3> {
             .and_then(|x| x.val_at(indices.1, indices.2, indices.3))
     }
 }
-impl<T: Clone + Copy, V3: FunVecD3<T>> MapValD4<T> for IndexMap<usize, V3> {
+
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+impl<T: Clone + Copy, V3: FunVecD3<T>> MapValD4<T> for indexmap::IndexMap<usize, V3> {
     #[inline(always)]
     fn get_val_by_key(&self, indices: Ind) -> Option<T> {
         self.get(&indices.0)
@@ -116,7 +117,7 @@ impl<T: Clone + Copy> MapValD4<T> for Box<dyn Fn(Ind) -> Option<T>> {
 }
 
 // ndarray
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 impl<T: Clone + Copy> MapValD4<T> for ndarray::Array4<T> {
     #[inline(always)]
     fn get_val_by_key(&self, key: Ind) -> Option<T> {

--- a/tests/funvecref_d2.rs
+++ b/tests/funvecref_d2.rs
@@ -1,5 +1,3 @@
-use indexmap::IndexMap;
-use orx_closure::Capture;
 use orx_funvec::*;
 use std::collections::{BTreeMap, HashMap};
 
@@ -38,31 +36,37 @@ fn test_variants() {
     assert_at(&vec);
     assert_iter_over(&vec);
 
-    struct Repo {
-        storage: IndexMap<(usize, usize), usize>,
-    }
-    impl Repo {
-        fn new() -> Self {
-            Self {
-                storage: IndexMap::from_iter(
-                    [
-                        ((0, 0), 0),
-                        ((0, 1), 1),
-                        ((0, 2), 2),
-                        ((1, 0), 1),
-                        ((1, 1), 2),
-                        ((1, 2), 3),
-                    ]
-                    .into_iter(),
-                ),
+    #[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+    {
+        use indexmap::IndexMap;
+        use orx_closure::Capture;
+
+        struct Repo {
+            storage: IndexMap<(usize, usize), usize>,
+        }
+        impl Repo {
+            fn new() -> Self {
+                Self {
+                    storage: IndexMap::from_iter(
+                        [
+                            ((0, 0), 0),
+                            ((0, 1), 1),
+                            ((0, 2), 2),
+                            ((1, 0), 1),
+                            ((1, 1), 2),
+                            ((1, 2), 3),
+                        ]
+                        .into_iter(),
+                    ),
+                }
+            }
+            fn get(&self, i: usize, j: usize) -> Option<&usize> {
+                self.storage.get(&(i, j))
             }
         }
-        fn get(&self, i: usize, j: usize) -> Option<&usize> {
-            self.storage.get(&(i, j))
-        }
+        let repo = Repo::new();
+        let vec = Capture(repo).fun_option_ref(|r, (i, j)| r.get(i, j));
+        assert_at(&vec);
+        assert_iter_over(&vec);
     }
-    let repo = Repo::new();
-    let vec = Capture(repo).fun_option_ref(|r, (i, j)| r.get(i, j));
-    assert_at(&vec);
-    assert_iter_over(&vec);
 }

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -1,11 +1,5 @@
-use indexmap::IndexMap;
 use orx_funvec::*;
-use std::collections::{BTreeMap, HashMap};
-use test_case::test_case;
 
-#[test_case(HashMap::from_iter([(0, 'a'), (10, 'b'), (20, 'c')].into_iter()) ; "HashMap")]
-#[test_case(BTreeMap::from_iter([(0, 'a'), (10, 'b'), (20, 'c')].into_iter()) ; "BTreeMap")]
-#[test_case(IndexMap::from_iter([(0, 'a'), (10, 'b'), (20, 'c')].into_iter()) ; "IndexMap")]
 fn at<F: FunVecD1Ref<char> + FunVecD1<char>>(map: F) {
     assert_eq!(Some(&'a'), map.ref_at(0));
     assert_eq!(Some(&'b'), map.ref_at(10));
@@ -18,9 +12,6 @@ fn at<F: FunVecD1Ref<char> + FunVecD1<char>>(map: F) {
     assert_eq!(None, map.val_at(1));
 }
 
-#[test_case(HashMap::from_iter([(0, 'a'), (2, 'b'), (4, 'c')].into_iter()) ; "HashMap")]
-#[test_case(BTreeMap::from_iter([(0, 'a'), (2, 'b'), (4, 'c')].into_iter()) ; "BTreeMap")]
-#[test_case(IndexMap::from_iter([(0, 'a'), (2, 'b'), (4, 'c')].into_iter()) ; "IndexMap")]
 fn iter<F: FunVecD1Ref<char> + FunVecD1<char>>(map: F) {
     let slice: Vec<_> = map.ref_iter_over(0..4).collect();
     assert_eq!(&slice, &[Some(&'a'), None, Some(&'b'), None]);
@@ -31,4 +22,44 @@ fn iter<F: FunVecD1Ref<char> + FunVecD1<char>>(map: F) {
     assert_eq!("abc", &joined);
     let joined = String::from_iter(map.val_iter_over(0..100).flatten());
     assert_eq!("abc", &joined);
+}
+
+#[test]
+fn hashmap_at_iter() {
+    use std::collections::HashMap;
+
+    at(HashMap::from_iter(
+        [(0, 'a'), (10, 'b'), (20, 'c')].into_iter(),
+    ));
+
+    iter(HashMap::from_iter(
+        [(0, 'a'), (2, 'b'), (4, 'c')].into_iter(),
+    ));
+}
+
+#[test]
+fn btreemap_at_iter() {
+    use std::collections::BTreeMap;
+
+    at(BTreeMap::from_iter(
+        [(0, 'a'), (10, 'b'), (20, 'c')].into_iter(),
+    ));
+
+    iter(BTreeMap::from_iter(
+        [(0, 'a'), (2, 'b'), (4, 'c')].into_iter(),
+    ));
+}
+
+#[cfg(any(feature = "impl_all", feature = "impl_indexmap"))]
+#[test]
+fn indexmap_at_iter() {
+    use indexmap::IndexMap;
+
+    at(IndexMap::from_iter(
+        [(0, 'a'), (10, 'b'), (20, 'c')].into_iter(),
+    ));
+
+    iter(IndexMap::from_iter(
+        [(0, 'a'), (2, 'b'), (4, 'c')].into_iter(),
+    ));
 }

--- a/tests/mcnf.rs
+++ b/tests/mcnf.rs
@@ -70,7 +70,7 @@ fn get_euclidean_distance(location1: (f64, f64), location2: (f64, f64)) -> i32 {
 }
 
 #[test]
-#[cfg(feature = "impl_ndarray")]
+#[cfg(any(feature = "impl_all", feature = "impl_ndarray"))]
 fn single_commodity_mcnf() {
     // mcnf problem with a single source and sink
     let source = 0;


### PR DESCRIPTION
`impl_indexmap` is defined to optionally include the `indexmap` crate and its funvec implementations.

`impl_all` is defined as a shorthand to simply include all implementations, which is handy for tests and prototypes.

```
[features]
default = []
impl_all = ["ndarray", "indexmap"]
impl_ndarray = ["ndarray"]
impl_indexmap = ["indexmap"]
```